### PR TITLE
Resolve issue 34

### DIFF
--- a/templates/partials/link-description.html
+++ b/templates/partials/link-description.html
@@ -7,13 +7,17 @@
     <div class="container">
         <div class="row">
             <div class="logo-box col-3">
-                <a class="stretched-link" href="{{ href }}">
+
                     {% if template %}
-                        <img id="link-image-{{ "{{link_id}}" }}" class="img-fluid float-end float-sm-none marble-logo-node"/>
+                        <a class="stretched-link" id="link-url-{{ "{{link_id}}" }}" href="{{ href }}">
+                            <img id="link-image-{{ "{{link_id}}" }}" class="img-fluid float-end float-sm-none marble-logo-node"/>
+                        </a>
                     {% else %}
-                        <img alt="{{ img_alt }}" src="{{ img_src }}" class="img-fluid float-end float-sm-none marble-logo-node"/>
+                        <a class="stretched-link" href="{{ href }}">
+                            <img alt="{{ img_alt }}" src="{{ img_src }}" class="img-fluid float-end float-sm-none marble-logo-node"/>
+                        </a>
                     {% endif %}
-                </a>
+
             </div>
             <div class="col-9 px-1">
                 <h2>{{ title }}</h2>

--- a/templates/site/ide.html
+++ b/templates/site/ide.html
@@ -30,6 +30,23 @@
             function nodeFilter([_name, data]) {
                 return data.services && data.services.some(service => service.keywords.includes("jupyterhub"))
             }
+
+            function setNodeLinkJupyter(name, data, node_id_suffix) {
+                let nodeLinkID = "link-url-" + node_id_suffix;
+
+                data.services.forEach((service) => {
+
+                    if(service.keywords.includes("jupyterhub")) {
+                        service.links.forEach((link) => {
+
+                            if(link.href.includes("jupyter") && link.rel == "service" ) {
+                                let nodeAnchor = document.getElementById(nodeLinkID);
+                                nodeAnchor.href = link.href;
+                            }
+                        })
+                    }
+                })
+            }
         </script>
         {% include "partials/node-content.html" %}
     {% endwith %}

--- a/templates/site/js/load-node-content.js
+++ b/templates/site/js/load-node-content.js
@@ -62,6 +62,7 @@ function buildNodeContent(registry) {
 
         Object.entries(nodes).forEach(([name, data], node_index) => {
             node_content.appendChild(buildNodeDescription(name, data, node_index, id_suffix));
+            setNodeLinkURL(name, data, node_index, id_suffix);
         })
     })
 }
@@ -71,6 +72,13 @@ function filterNodes(registry) {
         return Object.fromEntries(Object.entries(registry).filter(nodeFilter));
     }
     return registry
+}
+
+function setNodeLinkURL(name, data, node_index, row_id_suffix){
+    if (typeof setNodeLinkJupyter === 'function') {
+        let node_id_suffix = `${row_id_suffix}-${node_index}`;
+        setNodeLinkJupyter(name, data, node_id_suffix);
+    }
 }
 
 document.addEventListener("DOMContentLoaded", function () {


### PR DESCRIPTION
Move functionality to set node description link to each node's specific Jupyter page to the IDE page instead of load-node-content.js. Resolves #34 
- ide.html: Added function to set Jupyter link on the node description
- link-description.html: Included anchor tag in the template designation and added new ID attribute for the anchor tag
- load-node-content.js: Add call to function in ide.html