### PR TITLE
Resolve issue 52

### DIFF
--- a/templates/partials/node-info.html
+++ b/templates/partials/node-info.html
@@ -1,0 +1,3 @@
+<div class="container mt-3">
+    {{ content }}
+</div>

--- a/templates/site/js/node.js
+++ b/templates/site/js/node.js
@@ -124,8 +124,10 @@ document.addEventListener("DOMContentLoaded", function () {
             if (link.rel === "service") {
                 const elem = document.getElementById("url");
                 const link_elem = document.createElement("a");
+                /*
                 let small_logo_link = document.getElementById("small-logo-link");
                 small_logo_link.href = link.href;
+                */
 
                 Object.entries(link).forEach(([attr, value]) => link_elem.setAttribute(attr, value));
                 link_elem.innerText = link.href;
@@ -134,13 +136,29 @@ document.addEventListener("DOMContentLoaded", function () {
                 const icon_img = document.createElement("img")
                 icon_img.setAttribute("src", link.href)
 
+                /*
                 const background_elem = document.getElementById("background-icon");
                 background_elem.style.backgroundImage="url(" + link.href + ")";
                 background_elem.classList.add("info-background", "background-node-logo");
-
+                */
+                /*
                 const title_icon_img = document.getElementById("title-icon-img")
                 title_icon_img.classList.add("img-fluid", "d-block", "float-end");
                 title_icon_img.setAttribute("src", link.href);
+                */
+
+                const image_left = document.getElementById("image-left")
+                if(image_left){
+                    image_left.classList.add("mw-50", "mh-50");
+                    image_left.setAttribute("src", link.href);
+                }
+
+                const image_right = document.getElementById("image-right")
+                if(image_right){
+                    image_right.classList.add("img-fluid", "mw-25","mh-25");
+                    image_right.setAttribute("src", link.href);
+                }
+
             }
         })
 

--- a/templates/site/node.html
+++ b/templates/site/node.html
@@ -3,10 +3,32 @@
 
 {% block content %}
     {% include "partials/banner.html" %}
-    <div class="container mt-3">
-        <div class="row g-0 border rounded d-flex flex-column position-static overflow-hidden flex-md-row mb-4 shadow-sm h-md-250 position-relative info-background">
-            <div class="col-12 col-sm-8 px-2">
+
+    {% with %}
+    {% set img_location = "left" %}
+    {% if img_location == "left" %}
+        {% set border_class = "border-start" %}
+    {% endif %}
+
+    {% if img_location == "right" %}
+        {% set border_class = "border-end" %}
+    {% endif %}
+
+    {% set content %}
+
+
+
+    <!--<div class="container mt-3">-->
+
+        <div class="row g-0  d-flex flex-column position-static overflow-hidden flex-md-row mb-4 shadow-sm h-md-250 position-relative info-background">
+
+            <div class="col-12 col-sm-8 px-2 {{ border_class }}">
                 <div class="row">
+                    {% if img_location == "left" %}
+                        <div class="col-3 d-block d-lg-block">
+                            <img id="image-left" class="w-sm-100 mt-sm-5 mt-lg-0 mx-auto d-block  {{ img_class|default('') }}" src="{{ img_src }}" width="100%"/>
+                        </div>
+                    {% endif %}
                     <div class="col-9">
                         <!--H2 title -->
                         <div id="name" class="mb-0"></div>
@@ -43,10 +65,16 @@
 
                         </div>
                     </div>
-                    <div class="col-3 pt-4">
-                        <!-- Small sharp icon next to title -->
+                    {% if img_location == "right" %}
+                        <div class="col-3 d-block d-lg-block">
+                            <img id="image-right" class="w-sm-100 mt-sm-5 mt-lg-0 mx-auto d-block img-fluid {{ img_class|default('') }}" src="{{ img_src }}" width="100%"/>
+                        </div>
+                    {% endif %}
+
+                    <!--<div class="col-3 pt-4">
+
                         <a id="small-logo-link" target="_blank"><img id="title-icon-img"></a>
-                    </div>
+                    </div>-->
                 </div>
                 <div class="row">
                     <div class="col-12 text-center">
@@ -55,22 +83,21 @@
                 </div>
                 <div class="row">
                     <div class="col-12">
-                        <div id="services" class="table-responsive"></div>
+                        <div id="services" class="table-responsive border rounded"></div>
                     </div>
                 </div>
             </div>
+<!--
             <div class="col-1 col-sm-4 d-none d-lg-block overflow-hidden shadow-lg">
-                <!--Sets logo as background image-->
-                <div id="background-icon">
-                    <!--Div used to apply blur effect to background image -->
-                    <div id="node-overlay-container" class="foreground-img-blur mb-auto">
-                        <!--Used to set sharp logo overlayed on blurred logo.  May be used in future -->
-                        <!--<img id="node-overlay-img" > -->
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
+
+
+            </div>-->
+
+       </div>
+    <!--</div>-->
+    {% endset %}
+    {% include "partials/info-row.html" %}
+    {% endwith %}
     <script src="js/node.js"></script>
     {% include "partials/pictures.html" %}
 {% endblock content %}

--- a/templates/site/node.html
+++ b/templates/site/node.html
@@ -5,30 +5,17 @@
     {% include "partials/banner.html" %}
 
     {% with %}
-    {% set img_location = "left" %}
-    {% if img_location == "left" %}
-        {% set border_class = "border-start" %}
-    {% endif %}
 
-    {% if img_location == "right" %}
-        {% set border_class = "border-end" %}
-    {% endif %}
+
 
     {% set content %}
 
 
-
-    <!--<div class="container mt-3">-->
-
         <div class="row g-0  d-flex flex-column position-static overflow-hidden flex-md-row mb-4 shadow-sm h-md-250 position-relative info-background">
 
-            <div class="col-12 col-sm-8 px-2 {{ border_class }}">
+            <!--<div class="col-12 col-sm-8 px-2 {{ border_class }}">-->
                 <div class="row">
-                    {% if img_location == "left" %}
-                        <div class="col-3 d-block d-lg-block">
-                            <img id="image-left" class="w-sm-100 mt-sm-5 mt-lg-0 mx-auto d-block  {{ img_class|default('') }}" src="{{ img_src }}" width="100%"/>
-                        </div>
-                    {% endif %}
+
                     <div class="col-9">
                         <!--H2 title -->
                         <div id="name" class="mb-0"></div>
@@ -65,26 +52,27 @@
 
                         </div>
                     </div>
-                    {% if img_location == "right" %}
-                        <div class="col-3 d-block d-lg-block">
-                            <img id="image-right" class="w-sm-100 mt-sm-5 mt-lg-0 mx-auto d-block img-fluid {{ img_class|default('') }}" src="{{ img_src }}" width="100%"/>
-                        </div>
-                    {% endif %}
+
+
+                    <div class="col-3 col-lg-2 d-block d-lg-block">
+                        <img id="image-right" class="w-sm-100 mt-2 px-auto d-block img-fluid {{ img_class|default('') }}" src="{{ img_src }}" />
+                    </div>
 
                     <!--<div class="col-3 pt-4">
 
                         <a id="small-logo-link" target="_blank"><img id="title-icon-img"></a>
                     </div>-->
                 </div>
-                <div class="row">
-                    <div class="col-12 text-center">
-                        <h4 class="text-decoration-underline">Services Available</h4>
-                    </div>
+
+            <!--</div>-->
+            <div class="row">
+                <div class="col-12 mt-2 text-center">
+                    <h4 class="text-decoration-underline">Services Available</h4>
                 </div>
-                <div class="row">
-                    <div class="col-12">
-                        <div id="services" class="table-responsive border rounded"></div>
-                    </div>
+            </div>
+            <div class="row">
+                <div class="col-12 mb-2">
+                    <div id="services" class="table-responsive border rounded"></div>
                 </div>
             </div>
 <!--
@@ -96,7 +84,7 @@
        </div>
     <!--</div>-->
     {% endset %}
-    {% include "partials/info-row.html" %}
+    {% include "partials/node-info.html" %}
     {% endwith %}
     <script src="js/node.js"></script>
     {% include "partials/pictures.html" %}


### PR DESCRIPTION
Change layout of node info page in accordance with feedback from Thursday October 19 meeting
- Removed large blurred image section
- Keep smaller node logo next to node stats/info section (Not as discussed [Steve wanted same layout as Remote Processing page], but the node logos ended up too large on the screen, pixelated, or ended up having too much white space around it )
- Create node info partial to hold node info section (instead of using info-row.html partial)
- Move table down so it is it's own row and spans the node stats and node logo