### PR TITLE
Only require installing requirements from one file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ project as well as tutorials (as a submodule under `marble-tutorials/`).
 ### To build the site
 
 ```shell
-python3 -m pip install -r requirements.txt -r marble-tutorials/tutorials/requirements.txt
+python3 -m pip install -r requirements.txt
 python3 build.py
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 jinja2==3.1.2
+-r marble-tutorials/tutorials/requirements.txt


### PR DESCRIPTION
Refer to requirements file in submodule from the top-level `requirements.txt` file so that we only need to refer to a single file when installing.