### PR TITLE
auto-update tutorials

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: gitsubmodule
+    directory: /
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Adds a dependabot rule to automatically create PRs to update the tutorials when they have been updated.
This should keep the tutorials up to date and we won't need to manually update them here every time.