### PR TITLE
 remove redundant css and fix image width 

### DIFF
--- a/static/css/marble.css
+++ b/static/css/marble.css
@@ -633,17 +633,14 @@ h6{
 }
 
 .student-user-image{
-    width: 100%;
     background-image: url("../images/student-user.jpg");
 }
 
 .researcher-user-image{
-    width: 100%;
     background-image: url("../images/researcher-user.jpg");
 }
 
 .hobbyist-user-image{
-    width: 100%;
     background-image: url("../images/hobbyist-user.jpg");
 }
 
@@ -1104,7 +1101,6 @@ h6{
     }
 
     .user-image-height{
-        width: 100%;
         height: auto;
     }
 
@@ -1241,7 +1237,6 @@ h6{
     }
 
     .user-image-height{
-        width: 100%;
         height: auto;
     }
 

--- a/templates/partials/usage-section.html
+++ b/templates/partials/usage-section.html
@@ -22,7 +22,7 @@
 </div>
 
 <div class="d-flex d-lg-none w-100 g-0">
-    <div id="{{ id }}" class="d-flex flex-column">
+    <div id="{{ id }}" class="d-flex flex-column w-100">
         <div class="d-flex user-image user-image-height {{ image_class }}">
             <div class="d-flex align-items-end w-100">
                 <div class="d-flex justify-content-center py-5 w-100 getStartedOpacity">


### PR DESCRIPTION
- `width: 100%` was repeated multiple times for classes that were applied to the same elements. This made it difficult to tell which class was overriding which other class
- depending on the size of the background image, the image wasn't covering the full width of the screen. This fixes that by setting the width of the image's container to 100% width as well.

Fixes #132 