### PR TITLE
Fix website styling

### DIFF
--- a/static/css/marble.css
+++ b/static/css/marble.css
@@ -39,7 +39,7 @@
     --black-opacity-midlight: rgba(0,0,0,0.30);
     --black-opacity-mid: rgba(0,0,0,0.5);
     --opaque-light-grey: rgba(255,255,255, 0.3);
-    --linear-gradient-black: linear-gradient(90deg,transparent, #000000, transparent);
+    --linear-gradient-black: linear-gradient(90deg,transparent, rgba(0,0,0,0.5), transparent);
     --linear-gradient-marble: linear-gradient(90deg, #3F6BAE 3%, #6DA39F 33.33%, #D89E37 66.67%, #823628 100%);
     --white: #FFFFFF;
 
@@ -482,7 +482,11 @@ h6{
 }
 
 .banner-image-node{
+    background-color: var(--black);
     background-image: url(../images/banner/banner-nodes.jpg);
+    background-size: clamp(700px, 80%, 80%) auto;
+    background-repeat: no-repeat;
+    background-position: center;
     z-index: -99;
 }
 
@@ -514,6 +518,14 @@ h6{
 
 .banner-overlay-container{
     min-height: 100vh;
+    padding: 60px 0 0 0;
+    display: flex;
+    align-items: center;
+    background-color: var(--background-transparent);
+}
+
+.banner-overlay-container-node{
+    min-height: 60vh;
     padding: 60px 0 0 0;
     display: flex;
     align-items: center;
@@ -1125,6 +1137,17 @@ h6{
     }
 
     /*Node*/
+    .node-menu-container a:not(:last-child) {
+        margin-right: 20px;
+    }
+
+    .margin-node-menu-container {
+        margin-left: 0px;
+        margin-top: 0px;
+        margin-right: 0px;
+        margin-bottom: 20px;
+    }
+
     .node-image-background {
         width: 100%;
         height: 864px;
@@ -1282,15 +1305,8 @@ h6{
         line-height: var(--line-height-normal);
     }
 
-    .margin-node-menu-container {
-        margin-left: 0px;
-        margin-top: 0px;
-        margin-right: 0px;
-        margin-bottom: 20px;
-    }
-
     .node-menu-container a:not(:last-child) {
-        margin-right: 20px;
+        margin-right: 50px;
     }
 
     .node-image-background{
@@ -1488,10 +1504,6 @@ h6{
         margin-top: 25px;
         margin-right: 0px;
         margin-bottom: 20px;
-    }
-
-    .node-menu-container a:not(:last-child) {
-        margin-right: 20px;
     }
 
     .margin-node-menu-item {

--- a/templates/partials/banner.html
+++ b/templates/partials/banner.html
@@ -43,7 +43,7 @@
             {% set opacity_overlay_class = "banner-overlay-opacity" %}
         {% endif %}
         <div id="banner-image" class="d-block bg opacity-30 bg-position-center-center bg-attachment-fixed {{ banner_background_class }}"></div>
-        <div class="banner-overlay-container {{ opacity_overlay_class }}">
+        <div class="banner-overlay-container-node {{ opacity_overlay_class }}">
            <div class="container-fluid">
                <div class="d-flex flex-column justify-content-center w-100">
                    <div class="d-flex justify-content-center w-100">

--- a/templates/site/node.html
+++ b/templates/site/node.html
@@ -9,14 +9,14 @@
 {% with page = "node" %}
     {% set banner_background_class= "banner-image-node" %}
     {% set banner_title_class = "banner-title-node" %}
-    {% set page_slogan = "<span>Unlocking Data Access and Analysis with</span><br><span>Marble’s Federated Architecture</span>" %}
+    {% set page_slogan = "<span>Unlocking Data Access and Analysis with</span><span>Marble’s Federated Architecture</span>" %}
     {%  set value_statement = "Marble’s federated architecture empowers data climate investigator to seamlessly
     access data and analysis tools from any server on the Marble network." %}
 
     {% include "partials/banner.html" %}
 {% endwith %}
 
-    <div class="container-fluid d-flex justify-content-center mt-5 w-100 margin-content-section">
+    <div class="container-fluid d-flex justify-content-center mt-5 w-100">
         <div class="row">
             <div class="d-flex w-100">
                 <div class="d-flex flex-column align-items-center justify-content-lg-center">


### PR DESCRIPTION
Fixes #151
Fixes #152

marble.css
------------
Changes made from feedback from Issue 151 and Issue 152
- Changed linear gradient background on Node page to an opaque black
- Added changes to Node page static image background
: shrunk image to 80% of original size
: limited image shrink to 700px width
: added black background to fill in rest of div
: shrunk banner size as per design

- Added specific class for the banner image on Node page so changes don't affect other pages

- Moved margin classes for node menu into <576px media query
- Increased margin for ndoe menu to 50px in screen sizes larger than 576px



banner.html
-------------
Made specific banner overlay container class for Node page

Node.html
----------

- Removed <br> tag from slogan
- Removed bottom margin from introduction section