### PR TITLE
Fix website about icons rendering pixellated / overfilled with colour

### DIFF
--- a/templates/layouts/main.html
+++ b/templates/layouts/main.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css'>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" 
+    integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" 
+    crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet"
           integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"

--- a/templates/partials/executive-committee-section.html
+++ b/templates/partials/executive-committee-section.html
@@ -10,15 +10,15 @@
         "links": [
             {
                 "href": "https://github.com/huard",
-                "icon_class": "fab fa-github fa-lg"
+                "icon_class": "fa-brands fa-github fa-lg"
             },
             {
                 "href": "https://www.researchgate.net/profile/David-Huard",
-                "icon_class": "fab fa-researchgate fa-lg"
+                "icon_class": "fa-brands fa-researchgate fa-lg"
             },
             {
                 "href": "https://www.linkedin.com/in/david-huard/",
-                "icon_class": "fab fa-linkedin fa-lg"
+                "icon_class": "fa-brands fa-linkedin fa-lg"
             }
         ]
     },
@@ -33,19 +33,19 @@
         "links": [
             {
                 "href": "https://github.com/fmigneault/",
-                "icon_class": "fab fa-github fa-lg"
+                "icon_class": "fa-brands fa-github fa-lg"
             },
             {
                 "href": "https://www.researchgate.net/profile/Francis-Charette-Migneault",
-                "icon_class": "fab fa-researchgate fa-lg"
+                "icon_class": "fa-brands fa-researchgate fa-lg"
             },
             {
                 "href": "https://www.linkedin.com/in/francis-charette-migneault/",
-                "icon_class": "fab fa-linkedin fa-lg"
+                "icon_class": "fa-brands fa-linkedin fa-lg"
             },
             {
                 "href": "https://orcid.org/0000-0003-4862-3349",
-                "icon_class": "fab fa-orcid fa-lg"
+                "icon_class": "fa-brands fa-orcid fa-lg"
             }
         ]
     },
@@ -60,7 +60,7 @@
         "links": [
             {
                 "href": "https://github.com/mishaschwartz/",
-                "icon_class": "fab fa-github fa-lg"
+                "icon_class": "fa-brands fa-github fa-lg"
             }
         ]
     }

--- a/templates/partials/profile-card.html
+++ b/templates/partials/profile-card.html
@@ -29,7 +29,7 @@
                         {% set href = organization["href"] %}
                         {% set title = organization["name"] %}
                         {% set text = organization["name"] %}
-                        {% set icon_class = organization["icon_class"]|default("fa-building-columns") %}
+                        {% set icon_class = organization["icon_class"]|default("fa-solid fa-building-columns") %}
                         {% include "partials/profile-link.html" %}
                     {% endwith %}
             {% endif %}

--- a/templates/partials/profile-link.html
+++ b/templates/partials/profile-link.html
@@ -2,7 +2,7 @@
    title="{{ title }}"
    href="{{ href }}"
    target="_blank">
-    <i class="fa-solid {{ icon_class }}
+    <i class="{{ icon_class }}
               {{ 'profile-icon-primary' if href else 'profile-icon-grey disabled' }}"></i>
     {{ text }}
 </a>

--- a/templates/partials/scientific-committee-section.html
+++ b/templates/partials/scientific-committee-section.html
@@ -20,15 +20,15 @@
         "links": [
             {
                 "href": "https://github.com/huard",
-                "icon_class": "fab fa-github fa-lg"
+                "icon_class": "fa-brands fa-github fa-lg"
             },
             {
                 "href": "https://www.researchgate.net/profile/David-Huard",
-                "icon_class": "fab fa-researchgate fa-lg"
+                "icon_class": "fa-brands fa-researchgate fa-lg"
             },
             {
                 "href": "https://www.linkedin.com/in/david-huard/",
-                "icon_class": "fab fa-linkedin fa-lg"
+                "icon_class": "fa-brands fa-linkedin fa-lg"
             }
         ]
     },
@@ -43,19 +43,19 @@
         "links": [
             {
                 "href": "https://www.concordia.ca/faculty/damon-matthews.html",
-                "icon_class": "fa-user fa-lg"
+                "icon_class": "fa-solid fa-user fa-lg"
             },
             {
                 "href": "https://scholar.google.com/citations?user=BY1jk5kAAAAJ",
-                "icon_class": "fab fa-google-scholar fa-lg"
+                "icon_class": "fa-brands fa-google-scholar fa-lg"
             },
             {
                 "href": "https://twitter.com/damon_matthews",
-                "icon_class": "fab fa-twitter fa-lg"
+                "icon_class": "fa-brands fa-twitter fa-lg"
             },
             {
                 "href": "https://www.linkedin.com/in/damon-matthews-b47a5210/",
-                "icon_class": "fab fa-linkedin fa-lg"
+                "icon_class": "fa-brands fa-linkedin fa-lg"
             }
         ]
     },
@@ -70,7 +70,7 @@
         "links": [
             {
                 "href": "https://www.linkedin.com/in/samuelfoucher/",
-                "icon_class": "fab fa-linkedin fa-lg"
+                "icon_class": "fa-brands fa-linkedin fa-lg"
             }
         ]
     },
@@ -85,11 +85,11 @@
         "links": [
             {
                 "href": "https://www.researchgate.net/lab/Daniel-McKenney-Lab",
-                "icon_class": "fab fa-researchgate fa-lg"
+                "icon_class": "fa-brands fa-researchgate fa-lg"
             },
             {
                 "href": "https://ostrnrcan-dostrncan.canada.ca/browse/author?scope=45538ec0-c247-4f18-b907-e38e23f4c025&value=McKenney,%20D.%20W.",
-                "icon_class": "fab fa-canadian-maple-leaf fa-lg"
+                "icon_class": "fa-brands fa-canadian-maple-leaf fa-lg"
             }
         ]
     }


### PR DESCRIPTION
Fixes #155

Removed fa-solid from profile-link.html.  Prevents fontawesome icon from rendering overfilled with colour.

Also:
- Upgraded fontawesome to 6.5.2
- Changed fontawesome brand class to use 6.5.2 version